### PR TITLE
Remove null-like values and get whole queueUser object

### DIFF
--- a/konecty-opportunity.html
+++ b/konecty-opportunity.html
@@ -4,9 +4,9 @@
 			<input type="text" id="node-input-server" placeholder="Konecty Server">
 	</div>
 	<div class="form-row">
-	  <label for="node-input-token"><i class="icon-key"></i> <span data-i18n="konecty-contact.label.token"></span></label>
-	  <input type="text" id="node-input-token" data-i18n="[placeholder]konecty-contact.label.token">
-	</div>
+		<label for="node-input-token"><i class="icon-key"></i> <span data-i18n="konecty-opportunity.label.token"></span></label>
+		<input type="text" id="node-input-token" data-i18n="[placeholder]konecty-opportunity.label.token">
+	  </div>
 	<div class="form-row">
 			<label for="node-input-name"><i class="fa fa-tag"></i>  <span data-i18n="konecty-opportunity.label.name"></span></label>
 			<input type="text" id="node-input-name" data-i18n="[placeholder]konecty-opportunity.label.name">

--- a/konecty-queue.js
+++ b/konecty-queue.js
@@ -35,7 +35,7 @@ module.exports = function(RED) {
 			node.status({ fill: 'blue', shape: 'ring', text: RED._('konecty-queue.label.running') });
 			apiInstance
 				.getNextOnQueue(id)
-				.then(({ success, user: { user } }) => {
+				.then(({ success, user }) => {
 					if (success) {
 						node.send([
 							{

--- a/konecty-save.html
+++ b/konecty-save.html
@@ -173,7 +173,7 @@
 												.appendTo(row)
 												.typedInput({
 													default: 'msg',
-													types: ['msg', 'flow', 'global', 'str', 'env']
+													types: ['msg', 'flow', 'global', 'str', 'env', 'jsonata']
 												});
 											break;
 										case 'email':
@@ -227,7 +227,7 @@
 												.appendTo(row)
 												.typedInput({
 													default: 'msg',
-													types: ['msg', 'flow', 'global', 'bool', 'env']
+													types: ['msg', 'flow', 'global', 'bool', 'env', 'jsonata']
 												});
 											break;
 										case 'address':

--- a/konecty-save.js
+++ b/konecty-save.js
@@ -29,7 +29,7 @@ module.exports = function(RED) {
 				return;
 			}
 
-			const body = data.reduce((acc, { n, t, vt, v, il }) => {
+			let body = data.reduce((acc, { n, t, vt, v, il }) => {
 				let value;
 				switch (t) {
 					case 'email':
@@ -103,6 +103,26 @@ module.exports = function(RED) {
 					return { ...acc, [n]: [value] };
 				}
 				return { ...acc, [n]: value };
+			}, {});
+			
+			// Remove null-like values from body
+			body = Object.keys(body).reduce((accum, key) => {
+				const item = body[key];
+				if (item == null) {
+					return accum;
+				}
+				if (Array.isArray(item)) {
+					const first = item[0];
+					if (first == null || (first.__proto__ === Object.prototype && first.hasOwnProperty('_id') && first._id == null)) {
+						return accuml
+					}
+				}
+				if (item.__proto__ === Object.prototype) {
+					if (item.hasOwnProperty('_id') && item._id == null) {
+						return accum;
+					}
+				}
+				return Object.assign(accum, { [key]: item });
 			}, {});
 
 			const handleKonectyResponse = ({ success, data, errors }) => {

--- a/konecty-search.html
+++ b/konecty-search.html
@@ -1,7 +1,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js" charset="utf-8"></script>
 
 <script type="text/x-red" data-template-name="konecty-search">
-	<!--5-->
+	<!--6-->
 	<input type="hidden" id="node-input-filter">
 	<div class="form-row">
 	  <label for="node-input-name"><i class="icon-tag"></i> Name</label>


### PR DESCRIPTION
- Remove null-like objects from the after-parsed body on the create-opportunity nodes;
- Fix create-opportunity token layout;
- Add Jsonada support for some more fields;
- Get whole queueUser object when retrieving it, instead of getting only the user as previously.